### PR TITLE
Update regex to parse logbook for FCR-D

### DIFF
--- a/pycheckwatt/__init__.py
+++ b/pycheckwatt/__init__.py
@@ -143,7 +143,7 @@ class CheckwattManager:
 
     def _extract_fcr_d_state(self):
         pattern = re.compile(
-            r"\[ FCR-D (ACTIVATED|DEACTIVATE|FAIL ACTIVATION) \] (?:(?:\d+x)?\s?(\S+) --(\d+)-- | (?:(?:UP|DOWN) (?:\d+,\d+) Hz ))((?:(\d+,\d+)\/(\d+,\d+)\/)?(\d+,\d+) %)\s+\((\d+,\d+\/\d+,\d+|\d+) kW\) (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"  # noqa: E501
+             r"\[ FCR-D (ACTIVATED|DEACTIVATE|FAIL ACTIVATION) \] (?:(?:\d+x)?\s?(\S+) --(\d+)-- | (?:(?:UP|DOWN) (?:\d+,\d+) Hz ))((?:(\d+,\d+)\/(\d+,\d+)\/)?(\d+,\d+|[A-Z]+) %)\s+\((\d+,\d+\/\d+,\d+|\d+\/\d+|\d+) kW\)\s*-?\s*.*?(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"  # noqa: E501
         )
         for entry in self.logbook_entries:
             match = pattern.search(entry)

--- a/pycheckwatt/__init__.py
+++ b/pycheckwatt/__init__.py
@@ -143,7 +143,7 @@ class CheckwattManager:
 
     def _extract_fcr_d_state(self):
         pattern = re.compile(
-            r"\[ FCR-D (ACTIVATED|DEACTIVATE|FAIL ACTIVATION) \] ((\d+x)?\s?(\S+) --(\d+)-- | (UP (\d+,\d+) Hz ))(((\d+,\d+)\/(\d+,\d+)\/)?(\d+,\d+) %)\s+\((\d+,\d+\/\d+,\d+|\d+) kW\) (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"  # noqa: E501
+            r"\[ FCR-D (ACTIVATED|DEACTIVATE|FAIL ACTIVATION) \] (?:(?:\d+x)?\s?(\S+) --(\d+)-- | (?:(?:UP|DOWN) (?:\d+,\d+) Hz ))((?:(\d+,\d+)\/(\d+,\d+)\/)?(\d+,\d+) %)\s+\((\d+,\d+\/\d+,\d+|\d+) kW\) (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"  # noqa: E501
         )
         for entry in self.logbook_entries:
             match = pattern.search(entry)

--- a/pycheckwatt/__init__.py
+++ b/pycheckwatt/__init__.py
@@ -143,7 +143,7 @@ class CheckwattManager:
 
     def _extract_fcr_d_state(self):
         pattern = re.compile(
-            r"\[ FCR-D (ACTIVATED|DEACTIVATE|FAIL ACTIVATION) \] (\S+) --(\d+)-- ((\d+,\d+)/(\d+,\d+)/(\d+,\d+) %) \((\d+) kW\) (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"  # noqa: E501
+            r"\[ FCR-D (ACTIVATED|DEACTIVATE|FAIL ACTIVATION) \] ((\d+x)?\s?(\S+) --(\d+)-- | (UP (\d+,\d+) Hz ))(((\d+,\d+)\/(\d+,\d+)\/)?(\d+,\d+) %)\s+\((\d+,\d+\/\d+,\d+|\d+) kW\) (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"  # noqa: E501
         )
         for entry in self.logbook_entries:
             match = pattern.search(entry)

--- a/tests/unit/test_checkwatt_manager.py
+++ b/tests/unit/test_checkwatt_manager.py
@@ -216,10 +216,10 @@ class TestPropertyAccess:
 
         # FCR-D state properties should be populated from logbook
         assert manager.fcrd_state == "ACTIVATED"
-        assert manager.fcrd_power == "7"
-        assert manager.fcrd_timestamp == "2024-07-07 00:08:19"
-        assert manager.fcrd_percentage_up == "97,7"
-        assert manager.fcrd_percentage_down == "99,3"
+        assert manager.fcrd_power == "10,0/10,0"
+        assert manager.fcrd_timestamp == "2025-01-01 00:04:45"
+        assert manager.fcrd_percentage_up == "96,5"
+        assert manager.fcrd_percentage_down == "106,3"
 
     def test_properties_fail_without_data(self):
         """Test that properties fail appropriately when data isn't loaded."""


### PR DESCRIPTION
There appears to have been some changes in the logbook over time and this regex should improve fetching the data.

The existing regex supports the old format
`[ FCR-D ACTIVATED ] example@example.com --12345-- 97,7/0,5/99,3 % (7 kW) 2024-07-07 00:08:19 API-BACKEND`
In recent logs the power is defined as `(7,0/7,0 kW)`. There also appears to be an intermediate definition of `(7/7 kW)` but this regex does not handle those cases.

This new regex also handles both the failed activation logs as well as deactivation in the format of:
`[ FCR-D FAIL ACTIVATION ] 54x example@example.com --12345-- 85,9/0,6/97,0 % (10,0/10,0 kW) 2025-04-24 00:02:57 API-BACKEND`
`[ FCR-D DEACTIVATE ]  UP 49,83 Hz 0,0 %  (6 kW) 2025-01-31 00:16:00 API-BACKEND`

On some occasions the power is identified as `INF` but that is not handled by this regex.

Otherwise the changes should be backwards compatible with the note that group 8 changes from `7` to `7,0/7,0`.