### PR TITLE
Fixed fcrd_today_net_revenue

### DIFF
--- a/pycheckwatt/__init__.py
+++ b/pycheckwatt/__init__.py
@@ -1073,8 +1073,8 @@ class CheckwattManager:
         revenue = 0
         if self.revenue is not None:
             if len(self.revenue["Revenue"]) > 0:
-                if "NetRevenue" in self.revenue[0]:
-                    revenue = self.revenue[0]["NetRevenue"]
+                if "NetRevenue" in self.revenue["Revenue"][0]:
+                    revenue = self.revenue["Revenue"][0]["NetRevenue"]
 
         return revenue
 


### PR DESCRIPTION
Noticed that pycheckwatt had issues as per below in ha-checkwatt:
ERROR (MainThread) [custom_components.checkwatt] Unexpected error fetching checkwatt data
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 380, in _async_refresh
self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/checkwatt/__init__.py", line 401, in _async_update_data
  self.fcrd_today_net_revenue = cw_inst.fcrd_today_net_revenue
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.13/site-packages/pycheckwatt/__init__.py", line 1076, in fcrd_today_net_revenue
  if "NetRevenue" in self.revenue[0]:
                      ~~~~~~~~~~~~^^^
This fix works in the example.py at least but I suck at debugging in HA so will hope someone else can pick up from here. 