### PR TITLE
Updated kill switch handling by treating http 404 file not found as ok

### DIFF
--- a/pycheckwatt/__init__.py
+++ b/pycheckwatt/__init__.py
@@ -213,6 +213,13 @@ class CheckwattManager:
                     )
                     return False
 
+                if response.status == 404:
+                    # We are OK to continue since the killswitch file does not exist
+                    _LOGGER.debug(
+                        "CheckWatt accepted and not enabled the kill-switch since file does not exist"
+                    )
+                    return True
+
                 if response.status == 401:
                     _LOGGER.error(
                         "Unauthorized: Check your CheckWatt authentication credentials"


### PR DESCRIPTION
Updated kill switch handling by treating http 404 file not found as ok to run.
Not sure what the agreement with Checkwatt was though so might be that we should treat is as a block instead if the file is not present. 