### PR TITLE
Do not return RpiSerial for old RPI1Bs etc.

### DIFF
--- a/pycheckwatt/__init__.py
+++ b/pycheckwatt/__init__.py
@@ -1184,8 +1184,9 @@ class CheckwattManager:
         if self.customer_details is not None:
             meters = self.customer_details.get("Meter", [])
             for meter in meters:
-                if "RpiSerial" in meter:
-                    return meter["RpiSerial"].upper()
+                if "RpiSerial" in meter and "RpiModel" in meter:
+                    if meter["RpiModel"].find('CM') == 0:
+                        return meter["RpiSerial"].upper()
 
         _LOGGER.warning("Unable to find RPi Serial")
         return None


### PR DESCRIPTION
- I had an old CW installation where a RPI1B was used. But we are only interested in CM10 meters. So, when returning the serial, make sure it's a CM.